### PR TITLE
Fix underscores in link being formatted as markdown

### DIFF
--- a/posts/haskell-ecosystem-requests.md
+++ b/posts/haskell-ecosystem-requests.md
@@ -79,7 +79,7 @@ goals/agendas/plans being made privately and not shared, which leads
 to an inability of people outside of an inner circle to
 contribute. See, for example:
 
-* https://np.reddit.com/r/haskell/comments/7tykqi/should_stackage_ignore_version_bounds/dtgn1eb/
+* [https://np.reddit.com/r/haskell/comments/7tykqi/should_stackage_ignore_version_bounds/dtgn1eb/](https://np.reddit.com/r/haskell/comments/7tykqi/should_stackage_ignore_version_bounds/dtgn1eb/)
 
 I would like to recommend some maintainer guidelines be put in place
 for any core Haskell packages and projects. (What constitutes "core"


### PR DESCRIPTION
In the existing version, the link itself works but is cut off after `should`, and then `stackage` and `version` are italicized, because of the underscores. I'm not sure if this is the best solution—something is clearly finding text that looks like links and making them links, and maybe the better solution is to make that not generate weird link text.