### PR TITLE
Just fixing a typo, take -> task :)

### DIFF
--- a/posts/rust-crash-course-09-tokio-0-2.md
+++ b/posts/rust-crash-course-09-tokio-0-2.md
@@ -204,7 +204,7 @@ impl<T> Future for JoinHandle<T> {
 }
 ```
 
-Calling `spawn` gives us back a `JoinHandle<T::Output>`. In our case, the `Future` we provide as input is `dating()`, which has an output of type `Result<(), std::io::Error>`. So that means the type of `take::spawn(dating())` is `JoinHandle<Result<(), std::io::Error>>`.
+Calling `spawn` gives us back a `JoinHandle<T::Output>`. In our case, the `Future` we provide as input is `dating()`, which has an output of type `Result<(), std::io::Error>`. So that means the type of `task::spawn(dating())` is `JoinHandle<Result<(), std::io::Error>>`.
 
 We also see that `JoinHandle` implements `Future`. So when we apply `.apply` to this value, we end up with whatever that `type Output = Result<T, JoinError>` thing is. Since we know that `T` is `Result<(), std::io::Error>`, this means we end up with `Result<Result<(), std::io::Error>, JoinError>`.
 


### PR DESCRIPTION
Fixes a typo from `take::spawn` to `task::spawn`