### PR TITLE
Reference to String intended?

### DIFF
--- a/posts/rust-crash-course-01-kick-the-tires-solutions.md
+++ b/posts/rust-crash-course-01-kick-the-tires-solutions.md
@@ -67,7 +67,7 @@ fn main() {
     printer(val);
 }
 
-fn printer(val: String) {
+fn printer(val: &String) {
     println!("The value is: {}", val);
 }
 ```


### PR DESCRIPTION
Just beginning to learn Rust and really like your posts. I think that in your first example you might have meant to prefix the String type with an ampersand.